### PR TITLE
resolve relative paths relative to config file:

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ repos:
 #   (a) makes changes to files within the repo, outputs a commit message to stdout, and exits with code 0
 #   (b) exits with a nonzero exit code
 change_cmd:
+# command paths can either be absolute paths, or paths relative to the configuration file.
   path: "/path/to/the/program"
   args: ["-a", "flag"]
 # post_cmds is a list of programs to run on each repo if changes have been made.

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type normalizePathTestCase struct {
+	configPath  string
+	commandPath string
+	expected    string
+}
+
+var normalizePathTests = []normalizePathTestCase{
+	{"/path/to/gitbot.yml", "/absolute/path/command.py", "/absolute/path/command.py"},
+	{"/path/to/gitbot.yml", "./some/rel/path.py", "/path/to/some/rel/path.py"},
+	{"/path/to/gitbot.yml", "git", "git"},
+}
+
+func TestNormalizePath(t *testing.T) {
+	for _, testCase := range normalizePathTests {
+		actual := NormalizePath(testCase.configPath, testCase.commandPath)
+		assert.Equal(t, testCase.expected, actual, "NormalizePath(%v, %v) failed", testCase.configPath, testCase.commandPath)
+	}
+}


### PR DESCRIPTION
- Currently relative paths are calculated relative to wherever you call
  gitbot, but I think it makes more sense for it to be relative to the
  config file it was written in.