### PR TITLE
Move towards multiple commits

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,11 +29,16 @@ func (c Command) Validate() error {
 	return nil
 }
 
+type RepoChanges struct {
+	ChangeCmds []Commands `yaml:change_cmds`
+	PostCmds   []Commands `yaml:post_cmds`
+}
+
 // Config for gitbot.
 type Config struct {
-	Repos     []string  `yaml:"repos"`
-	ChangeCmd Command   `yaml:"change_cmd"`
-	PostCmds  []Command `yaml:"post_cmds"`
+	Repos     []string      `yaml:"repos"`
+	Changes   []RepoChanges `yaml:"repo_changes"`
+	FinalCmds []Command     `yaml:"final_cmds"`
 }
 
 // NormalizePath will return an absolute path from a relative one, with


### PR DESCRIPTION
Hardly completed yet, but the diff you see here shows the kind of schema we could implement. 

The single command  -> multiple post-command framework could be generalized here. Perhaps it's ideal to simply provide a Python or Go script to do everything, per status quo, but in the cases of it being a couple `rm -rf` with a `sed -i ...`, the struct including multiple initial commands might be ideal. 

Still need to think about what the git commands look like, but in `main.go`, you can imagine looping over these ChangeRepo objects and making ChangeCmds that may lead to PostCmds.