### PR TITLE
Go Vendoring Standardization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 version.go
+gitbot

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2,7 +2,7 @@
 	"ImportPath": "github.com/Clever/gitbot",
 	"GoVersion": "go1.5.1",
 	"Packages": [
-		"./..."
+		"github.com/Clever/gitbot"
 	],
 	"Deps": [
 		{

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,15 @@ release: $(RELEASE_ARTIFACTS)
 
 clean:
 	rm -rf build release
+
+
+SHELL := /bin/bash
+PKGS := $(shell go list ./... | grep -v /vendor)
+GODEP := $(GOPATH)/bin/godep
+
+$(GODEP):
+	go get -u github.com/tools/godep
+
+vendor: $(GODEP)
+	$(GODEP) save $(PKGS)
+	find vendor/ -path '*/vendor' -type d | xargs -IX rm -r X # remove any nested vendor directories

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ export GO15VENDOREXPERIMENT = 1
 
 .PHONY: test $(PKGS) build clean vendor
 
+all: test build
+
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
 	go get github.com/golang/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 SHELL := /bin/bash
 PKG := github.com/Clever/gitbot
-SUBPKGS := 
-PKGS := $(PKG) $(SUBPKGS)
-GODEP := $(GOPATH)/bin/godep
-GOLINT := $(GOPATH)/bin/golint
+PKGS := $(shell go list ./... | grep -v /vendor)
 EXECUTABLE := gitbot
 VERSION := $(shell cat VERSION)
 BUILDS := \
@@ -18,19 +15,20 @@ ifeq "$(GOVERSION)" ""
 endif
 export GO15VENDOREXPERIMENT = 1
 
+.PHONY: test $(PKGS) build clean vendor
 
-.PHONY: test $(PKGS) build clean
-
-test: $(PKGS)
-
-$(GODEP):
-	go get github.com/tools/godep
-
+GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
 	go get github.com/golang/lint/golint
 
+GODEP := $(GOPATH)/bin/godep
+$(GODEP):
+	go get -u github.com/tools/godep
+
 build:
-	go build $(PKG)
+	go build -o bin/$(EXECUTABLE) $(PKG)
+
+test: $(PKGS)
 
 $(PKGS): $(GOLINT) version.go
 	gofmt -w=true $(GOPATH)/src/$@/*.go
@@ -60,14 +58,6 @@ release: $(RELEASE_ARTIFACTS)
 
 clean:
 	rm -rf build release
-
-
-SHELL := /bin/bash
-PKGS := $(shell go list ./... | grep -v /vendor)
-GODEP := $(GOPATH)/bin/godep
-
-$(GODEP):
-	go get -u github.com/tools/godep
 
 vendor: $(GODEP)
 	$(GODEP) save $(PKGS)

--- a/README.md
+++ b/README.md
@@ -76,3 +76,28 @@ github.com:
 - add a license/contributing.md to many repos
 - optimize images
 - programmatically change a common configuration file present in many repos
+
+## Changing Dependencies
+
+### New Packages
+
+When adding a new package, you can simply use `make vendor` to update your imports.
+This should bring in the new dependency that was previously undeclared.
+The change should be reflected in [Godeps.json](Godeps/Godeps.json) as well as [vendor/](vendor/).
+
+### Existing Packages
+
+First ensure that you have your desired version of the package checked out in your `$GOPATH`.
+
+When to change the version of an existing package, you will need to use the godep tool.
+You must specify the package with the `update` command, if you use multiple subpackages of a repo you will need to specify all of them.
+So if you use package github.com/Clever/foo/a and github.com/Clever/foo/b, you will need to specify both a and b, not just foo.
+
+```
+# depending on github.com/Clever/foo
+godep update github.com/Clever/foo
+
+# depending on github.com/Clever/foo/a and github.com/Clever/foo/b
+godep update github.com/Clever/foo/a github.com/Clever/foo/b
+```
+

--- a/README.md
+++ b/README.md
@@ -77,27 +77,7 @@ github.com:
 - optimize images
 - programmatically change a common configuration file present in many repos
 
-## Changing Dependencies
 
-### New Packages
+## Vendoring
 
-When adding a new package, you can simply use `make vendor` to update your imports.
-This should bring in the new dependency that was previously undeclared.
-The change should be reflected in [Godeps.json](Godeps/Godeps.json) as well as [vendor/](vendor/).
-
-### Existing Packages
-
-First ensure that you have your desired version of the package checked out in your `$GOPATH`.
-
-When to change the version of an existing package, you will need to use the godep tool.
-You must specify the package with the `update` command, if you use multiple subpackages of a repo you will need to specify all of them.
-So if you use package github.com/Clever/foo/a and github.com/Clever/foo/b, you will need to specify both a and b, not just foo.
-
-```
-# depending on github.com/Clever/foo
-godep update github.com/Clever/foo
-
-# depending on github.com/Clever/foo/a and github.com/Clever/foo/b
-godep update github.com/Clever/foo/a github.com/Clever/foo/b
-```
-
+Please view the [dev-handbook for instructions](https://github.com/Clever/dev-handbook/blob/master/golang/godep.md).


### PR DESCRIPTION
This PR was mostly autogenerated.

Changes to expect:
- removal of `*_test.go` files in /vendor
- addition of non go files in /vendor
- addtions to README.md & Makefile

**Before your merge!**:

- Please carefully check the Makefile changes
- Ensure that the build is passing
- Check that drone is using the proper image (Clever/drone-go:1.5)

Feel free to ping @natebrennand or #golang for clarification or help.

If you'd like more of an explanation please join us in #golang.