### PR TITLE
Add error log when running change command

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ func main() {
 			changecmd.Stdout = io.MultiWriter(os.Stdout, &changecmdstdout)
 			changecmd.Stderr = os.Stderr
 			if err := changecmd.Run(); err != nil {
+				log.Printf("%s: error running change command: %s"", repo, err)
 				log.Printf("%s: no changes to make", repo)
 				continue
 			}


### PR DESCRIPTION
## Overview
The error was hidden when running the change command. It would confuse people because they thought the process is done because of no changes being applied